### PR TITLE
fix ports to not use standart 5432, add db config, remove import Model

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: postgres:14-alpine
     user: postgres
     ports:
-      - "5432:5432"
+      - "54323:5432"
     environment:
       POSTGRES_USER: tester
       POSTGRES_PASSWORD: test-pwd

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "fake-entity-service",
-  "version": "0.1.3",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fake-entity-service",
-      "version": "0.1.3",
+      "version": "0.7.0",
+      "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
         "@types/jest": "27.0.2",
@@ -27,7 +28,7 @@
         "typescript": "^4.3.5"
       },
       "engines": {
-        "node": "16.17.1"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/sequelize/config/config.js
+++ b/sequelize/config/config.js
@@ -3,7 +3,7 @@ module.exports = {
   local: {
     dialect: 'postgres',
     host: 'localhost',
-    port: 5432,
+    port: 54323,
     username: 'tester',
     password: 'test-pwd',
     database: 'test-db',

--- a/src/fake-entity-core.service.ts
+++ b/src/fake-entity-core.service.ts
@@ -1,5 +1,3 @@
-import {Model} from "sequelize-typescript";
-
 export type SingleKeyRelation = {
   parent: string,
   nested: string

--- a/tests/sequelize-basics.int-spec.ts
+++ b/tests/sequelize-basics.int-spec.ts
@@ -11,6 +11,8 @@ import {Comment} from "./sequelize-models/comment.entity";
 import {FakeCommentService} from "./sequelize-factories/fake-comment.service";
 
 const sequelize = new Sequelize({
+  host: 'localhost',
+  port: 54323,
   database: 'test-db',
   dialect: 'postgres',
   username: 'tester',

--- a/tests/typeorm-basics.int-spec.ts
+++ b/tests/typeorm-basics.int-spec.ts
@@ -7,6 +7,8 @@ import {Post} from "./typeorm-models/post.entity";
 import {Comment} from "./typeorm-models/comment.entity";
 import {FakeCommentService} from "./typeorm-factories/fake-comment.service";
 const PostgresDataSource = new DataSource({
+  host: 'localhost',
+  port: 54323,
   type: 'postgres',
   database: 'test-db',
   username: 'tester',


### PR DESCRIPTION
Found the problem that package requires sequelize despite i use typeorm only.
Maybe removing of `import {Model}` will help.

Also when running tests foud that it conflicts with my system's postgres instance. Assumed that it would be better to use some other port to run tests.
