### PR TITLE
Fix NPM publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
+      - run: npm install -g npm@latest  # OIDC trusted publishing requires npm >=11.5.1
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,9 +48,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g npm@latest  # OIDC trusted publishing requires npm >=11.5.1
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fake-entity-service",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fake-entity-service",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^9.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-entity-service",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A fake database entities service for testing",
   "author": {
     "email": "mike.onofrienko@clockwise.software",


### PR DESCRIPTION
Summary
Migrate npm publishing from classic tokens to OIDC trusted publishing
Use Node.js 24 for publishing (includes npm v11 with native OIDC support)
Bump version to 0.10.2
Details
Classic npm tokens were revoked on December 9, 2025. This PR updates the CI workflow to use OIDC trusted publishing instead, which: